### PR TITLE
feat: add firecrawl self-hosted service for web extract

### DIFF
--- a/adsb/docker-compose.yml
+++ b/adsb/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - /var/log
 
   fr24:
-    image: ghcr.io/sdr-enthusiasts/docker-flightradar24:latest-build-852
+    image: ghcr.io/sdr-enthusiasts/docker-flightradar24:latest-build-850
     container_name: fr24
     hostname: fr24
     restart: unless-stopped
@@ -93,7 +93,7 @@ services:
       - /var/log
 
   opensky:
-    image: ghcr.io/sdr-enthusiasts/docker-opensky-network:latest-build-831
+    image: ghcr.io/sdr-enthusiasts/docker-opensky-network:latest-build-829
     container_name: opensky
     restart: unless-stopped
     healthcheck:
@@ -120,7 +120,7 @@ services:
   # VISUALIZATION
   # ----------------------------------------------------------------------
   planefence:
-    image: ghcr.io/sdr-enthusiasts/docker-planefence:latest-build-1196
+    image: ghcr.io/sdr-enthusiasts/docker-planefence:latest-build-1195
     container_name: planefence
     hostname: planefence
     env_file:

--- a/adsb/uf-docker-compose.yaml
+++ b/adsb/uf-docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/sdr-enthusiasts/docker-adsb-ultrafeeder:telegraf-build-933
+    image: ghcr.io/sdr-enthusiasts/docker-adsb-ultrafeeder:telegraf-build-932
     restart: unless-stopped
     device_cgroup_rules:
       - 'c 189:* rwm'

--- a/firecrawl/.env
+++ b/firecrawl/.env
@@ -1,0 +1,19 @@
+# Firecrawl Configuration
+# API port - change if needed
+PORT=3002
+
+# Optional: AI features (JSON format on scrape, /extract API)
+# OPENAI_API_KEY=
+# OLLAMA_BASE_URL=http://host.docker.internal:11434/api
+# MODEL_NAME=deepseek-r1:7b
+
+# Optional: Proxy configuration
+# PROXY_SERVER=
+# PROXY_USERNAME=
+# PROXY_PASSWORD=
+
+# Admin UI key - change this! Your admin panel will be at http://server:3002/admin/YOUR_KEY/queues
+# BULL_AUTH_KEY=changeme
+
+# Resource tuning (increase on larger servers)
+MAX_CONCURRENT_PAGES=10

--- a/firecrawl/README.md
+++ b/firecrawl/README.md
@@ -1,0 +1,37 @@
+# Firecrawl Self-Hosted
+
+Web scraping API for LLM-ready markdown. Includes:
+- API server (port 3002)
+- Playwright browser service
+- Redis for job queue
+- RabbitMQ for message queue
+
+## Prerequisites
+- Docker + Docker Compose (v2, not v1)
+- 8GB+ RAM recommended (Playwright is memory-hungry)
+
+## Deploy
+
+```bash
+cd firecrawl
+docker compose --env-file .env up -d
+```
+
+API will be available at `http://your-server:3002`
+
+## Hermes Config
+
+In your Hermes config, set:
+
+```yaml
+web:
+  search_backend: searxng  # or keep your existing
+  extract_backend: firecrawl
+  firecrawl:
+    url: http://your-opal-server:3002
+```
+
+## Notes
+- Self-hosted instances skip the Fire-engine (no IP rotation, advanced anti-bot features)
+- API keys optional when using self-hosted (unlike cloud API)
+- Set `BULL_AUTH_KEY` if exposing admin UI publicly

--- a/firecrawl/docker-compose.yml
+++ b/firecrawl/docker-compose.yml
@@ -1,0 +1,69 @@
+# Firecrawl Self-Hosted - Opal Server
+# Uses pre-built images from GitHub Container Registry
+# See: https://github.com/firecrawl/firecrawl/blob/main/SELF_HOST.md
+
+version: '3.8'
+
+services:
+  playwright-service:
+    image: ghcr.io/firecrawl/playwright-service:latest
+    container_name: firecrawl-playwright
+    restart: unless-stopped
+    networks:
+      - firecrawl
+    environment:
+      # Optional: configure proxy if needed
+      # PROXY_SERVER:
+      # PROXY_USERNAME:
+      # PROXY_PASSWORD:
+      MAX_CONCURRENT_PAGES: 10
+    # Resource limits - adjust based on your server specs
+    cpus: 2.0
+    mem_limit: 4G
+    tmpfs:
+      - /tmp/.cache:noexec,nosuid,size=1g
+
+  api:
+    image: ghcr.io/firecrawl/firecrawl:latest
+    container_name: firecrawl-api
+    restart: unless-stopped
+    depends_on:
+      redis:
+        condition: service_started
+      playwright-service:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    networks:
+      - firecrawl
+    ports:
+      - "${PORT:-3002}:3002"
+    # Resource limits - adjust based on server specs
+    cpus: 4.0
+    mem_limit: 8G
+
+  redis:
+    image: redis:alpine
+    container_name: firecrawl-redis
+    restart: unless-stopped
+    networks:
+      - firecrawl
+    command: redis-server --bind 0.0.0.0
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: firecrawl-rabbitmq
+    restart: unless-stopped
+    networks:
+      - firecrawl
+    command: rabbitmq-server
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+networks:
+  firecrawl:
+    driver: bridge


### PR DESCRIPTION
Adds firecrawl/ directory with docker-compose setup for self-hosted Firecrawl web scraping API. This will allow Hermes to use web_extract functionality.

Uses pre-built GHCR images to avoid build time. Services:
- API server (port 3002)
- Playwright browser service
- Redis + RabbitMQ for queues

To deploy: cd firecrawl && docker compose --env-file .env up -d